### PR TITLE
Do not save empty blocks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,31 +129,22 @@
 		<dependency>
 			<groupId>org.janelia.saalfeldlab</groupId>
 			<artifactId>n5</artifactId>
-			<version>2.2.0-SNAPSHOT</version>
-
-			<!-- can be removed once new n5 is released -->
-			<exclusions>
-				<exclusion>
-					<groupId>net.jpountz.lz4</groupId>
-					<artifactId>lz4</artifactId>
-				</exclusion>
-			</exclusions>
-
+			<version>2.2.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.janelia.saalfeldlab</groupId>
 			<artifactId>n5-imglib2</artifactId>
-			<version>3.3.0</version>
+			<version>3.5.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.janelia.saalfeldlab</groupId>
 			<artifactId>n5-hdf5</artifactId>
-			<version>1.0.3</version>
+			<version>1.0.4</version>
 		</dependency>
 		<dependency>
 			<groupId>net.imglib2</groupId>
 			<artifactId>imglib2-label-multisets</artifactId>
-			<version>0.8.1</version>
+			<version>0.9.0</version>
 		</dependency>
 		<dependency>
 			<groupId>info.picocli</groupId>
@@ -177,18 +168,6 @@
 			<scope>test</scope>
 		</dependency>
 
-		<!-- these can be removed once pom-scijava 26.0.0 is released -->
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>jcl-over-slf4j</artifactId>
-			<version>1.7.25</version>
-		</dependency>
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-log4j12</artifactId>
-			<version>1.7.25</version>
-		</dependency>
-
 	</dependencies>
 
 	<profiles>
@@ -199,7 +178,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-shade-plugin</artifactId>
-						<version>3.1.0</version>
+						<version>3.2.1</version>
 						<configuration>
 							<filters>
 								<filter>
@@ -257,7 +236,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-shade-plugin</artifactId>
-						<version>3.1.0</version>
+						<version>3.2.1</version>
 						<configuration>
 							<filters>
 								<filter>

--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
 		<dependency>
 			<groupId>org.janelia.saalfeldlab</groupId>
 			<artifactId>n5</artifactId>
-			<version>2.1.0</version>
+			<version>2.2.0-SNAPSHOT</version>
 
 			<!-- can be removed once new n5 is released -->
 			<exclusions>

--- a/src/main/java/org/janelia/saalfeldlab/label/spark/affinities/MakePredictionMask.java
+++ b/src/main/java/org/janelia/saalfeldlab/label/spark/affinities/MakePredictionMask.java
@@ -1,16 +1,14 @@
 package org.janelia.saalfeldlab.label.spark.affinities;
 
 import com.google.gson.annotations.Expose;
-import net.imglib2.FinalInterval;
-import net.imglib2.FinalRealInterval;
-import net.imglib2.Interval;
-import net.imglib2.RandomAccessible;
+import net.imglib2.*;
 import net.imglib2.algorithm.util.Grids;
 import net.imglib2.converter.Converters;
 import net.imglib2.img.array.ArrayImg;
 import net.imglib2.img.array.ArrayImgs;
 import net.imglib2.img.basictypeaccess.array.ByteArray;
 import net.imglib2.realtransform.AffineTransform3D;
+import net.imglib2.type.numeric.IntegerType;
 import net.imglib2.type.numeric.integer.UnsignedByteType;
 import net.imglib2.util.ConstantUtils;
 import net.imglib2.util.Intervals;
@@ -18,11 +16,7 @@ import net.imglib2.view.IntervalView;
 import net.imglib2.view.Views;
 import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaSparkContext;
-import org.janelia.saalfeldlab.n5.DataType;
-import org.janelia.saalfeldlab.n5.DatasetAttributes;
-import org.janelia.saalfeldlab.n5.GzipCompression;
-import org.janelia.saalfeldlab.n5.N5FSReader;
-import org.janelia.saalfeldlab.n5.N5Writer;
+import org.janelia.saalfeldlab.n5.*;
 import org.janelia.saalfeldlab.n5.imglib2.N5Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -389,7 +383,9 @@ public class MakePredictionMask {
 		@Override
 		public RandomAccessible<UnsignedByteType> get() {
 			try {
-				return Views.extendValue(Converters.convert(N5Utils.<UnsignedByteType>open(n5.get(), dataset), (s, t) -> t.setInteger(s.getIntegerLong()), new UnsignedByteType()), new UnsignedByteType(0));
+				final RandomAccessibleInterval<IntegerType<?>> img = (RandomAccessibleInterval) N5Utils.open(n5.get(), dataset);
+				final RandomAccessibleInterval<UnsignedByteType> convertedImg = Converters.convert(img, (s, t) -> t.setInteger(s.getIntegerLong()), new UnsignedByteType());
+				return Views.extendValue(convertedImg, new UnsignedByteType(0));
 			} catch (IOException e) {
 				throw new RuntimeException(e);
 			}

--- a/src/main/java/org/janelia/saalfeldlab/label/spark/convert/ConvertToLabelMultisetType.java
+++ b/src/main/java/org/janelia/saalfeldlab/label/spark/convert/ConvertToLabelMultisetType.java
@@ -1,7 +1,6 @@
 package org.janelia.saalfeldlab.label.spark.convert;
 
 import java.io.IOException;
-import java.io.Serializable;
 import java.lang.invoke.MethodHandles;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -243,17 +242,8 @@ public class ConvertToLabelMultisetType
 
 					return blockMaxId;
 				} )
-				.max( new LongComparator() );
+				.max( Comparator.naturalOrder() );
 
 		writer.setAttribute( outputDatasetName, MAX_ID_KEY, maxId );
-	}
-
-	private static final class LongComparator implements Comparator< Long >, Serializable
-	{
-		@Override
-		public int compare( final Long o1, final Long o2 )
-		{
-			return Long.compare( o1, o2 );
-		}
 	}
 }

--- a/src/main/java/org/janelia/saalfeldlab/label/spark/convert/ConvertToLabelMultisetType.java
+++ b/src/main/java/org/janelia/saalfeldlab/label/spark/convert/ConvertToLabelMultisetType.java
@@ -181,6 +181,12 @@ public class ConvertToLabelMultisetType
 
 		final N5Writer writer = N5Helpers.n5Writer( outputGroupName, blockSize );
 		final boolean outputDatasetExisted = writer.datasetExists( outputDatasetName );
+		if ( outputDatasetExisted )
+		{
+			final int[] existingBlockSize = writer.getDatasetAttributes( outputDatasetName ).getBlockSize();
+			if ( !Arrays.equals( blockSize, existingBlockSize ) )
+				throw new RuntimeException( "Cannot overwrite existing dataset when the block sizes are not the same." );
+		}
 		writer.createDataset( outputDatasetName, dimensions, blockSize, DataType.UINT8, compression );
 		writer.setAttribute( outputDatasetName, LABEL_MULTISETTYPE_KEY, true );
 		for ( final Entry< String, Class< ? > > entry : attributeNames.entrySet() )

--- a/src/main/java/org/janelia/saalfeldlab/label/spark/convert/ConvertToLabelMultisetType.java
+++ b/src/main/java/org/janelia/saalfeldlab/label/spark/convert/ConvertToLabelMultisetType.java
@@ -223,11 +223,17 @@ public class ConvertToLabelMultisetType
 					}
 					final RandomAccessibleInterval< LabelMultisetType > converted = Converters.convert( blockImg, converter, type );
 
-					N5LabelMultisets.saveLabelMultisetBlock(
+
+					final N5Writer localWriter = N5Helpers.n5Writer( outputGroupName, blockSize );
+					final long[] gridOffset = computeGridOffset( interval, blockSize );
+					// Empty blocks will not be written out.
+					// Delete blocks to avoid remnant blocks if overwriting.
+					deleteBlock( converted, localWriter, outputDatasetName, blockSize, gridOffset );
+					N5LabelMultisets.saveLabelMultisetNonEmptyBlock(
 							converted,
-							N5Helpers.n5Writer( outputGroupName, blockSize ),
+							localWriter,
 							outputDatasetName,
-							computeGridOffset( interval, blockSize ) // TODO: this parameter can be omitted with next release of n5-imglib2
+							gridOffset // TODO: this parameter can be omitted with next release of n5-imglib2
 						);
 
 					return blockMaxId;
@@ -251,6 +257,56 @@ public class ConvertToLabelMultisetType
 		public int compare( final Long o1, final Long o2 )
 		{
 			return Long.compare( o1, o2 );
+		}
+	}
+
+	private static void cropBlockDimensions(
+			final long[] max,
+			final long[] offset,
+			final long[] gridOffset,
+			final int[] blockDimensions,
+			final long[] croppedBlockDimensions,
+			final int[] intCroppedBlockDimensions,
+			final long[] gridPosition) {
+
+		for (int d = 0; d < max.length; ++d) {
+			croppedBlockDimensions[ d ] = Math.min( blockDimensions[ d ], max[ d ] - offset[ d ] + 1);
+			intCroppedBlockDimensions[ d ] = ( int ) croppedBlockDimensions[ d ];
+			gridPosition[ d ] = offset[ d ] / blockDimensions[ d ] + gridOffset[ d ];
+		}
+	}
+
+	private static final void deleteBlock(
+			final Interval interval,
+			final N5Writer n5,
+			final String dataset,
+			final int[] blockSize,
+			final long[] gridOffset ) throws IOException {
+
+		final Interval zeroMinInterval = new FinalInterval( Intervals.dimensionsAsLongArray( interval ) );
+		final int n = zeroMinInterval.numDimensions();
+		final long[] max = Intervals.maxAsLongArray( zeroMinInterval );
+		final long[] offset = new long[ n ];
+		final long[] gridPosition = new long[ n ];
+		final int[] intCroppedBlockSize = new int[ n ];
+		final long[] longCroppedBlockSize = new long[ n ];
+		for ( int d = 0; d < n; ) {
+			cropBlockDimensions(
+					max,
+					offset,
+					gridOffset,
+					blockSize,
+					longCroppedBlockSize,
+					intCroppedBlockSize,
+					gridPosition );
+			n5.deleteBlock( dataset, gridPosition );
+			for ( d = 0; d < n; ++d ) {
+				offset[ d ] += blockSize[ d ];
+				if ( offset[ d ] <= max[ d ] )
+					break;
+				else
+					offset[ d ] = 0;
+			}
 		}
 	}
 }


### PR DESCRIPTION
With this PR, empty blocks will not be stored anymore when
 - converting label data to `LabelMultisetType`, or
 - downsampling `LabelMultisetType` data.

To ensure that no remnant blocks remain when overwriting, all blocks need to be deleted before writing.

Similar https://github.com/saalfeldlab/n5-spark/pull/12, I had to create a `deleteBlocks` method that should probably be added to `n5-imglib2` in some form.

This needs some more testing.

@igorpisarev I will probably not be able to test and merge this PR before I leave Janelia. Feel free to modify this PR as you like, or disregard it if you have a better plan to ensure that empty blocks are not written.